### PR TITLE
chore: lottie-web should be peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
     "tsc:compile": "tsc",
     "tsc:compile:watch": "tsc --watch"
   },
-  "dependencies": {
-    "lottie-web": "^5.7.3"
-  },
   "devDependencies": {
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",
@@ -95,6 +92,7 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
+    "lottie-web": "^5.7.3",
     "prop-types": "^15.5.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"


### PR DESCRIPTION
Hey, as a third library, lottit-react should be pure,which means should not include `lottie-web`.