### PR TITLE
Remove reference to animationInstance on destroy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules
 /.docz
 /docs-dist
 build
+
+.DS_Store

--- a/src/hooks/useLottie.tsx
+++ b/src/hooks/useLottie.tsx
@@ -149,6 +149,10 @@ const useLottie = (
    */
   const destroy = (): void => {
     animationInstanceRef.current?.destroy();
+
+    // Cleaning reference so separate cleanups are skipped.
+    // Without it internal lottie instance throws exceptions as it already cleared itself on destroy.
+    animationInstanceRef.current = undefined;
   };
 
   /*


### PR DESCRIPTION
Currently if destroy is called on unmount, it causes exceptions when in next step lottie-react tries to remove them from already destroyed animationInstance.

Clearing current on destroy ensures that unnecessary cleanups will be skipped. 

# Reproduction

1. Invoke destroy on lottieRef.current on unmount
2. Create logic which removes whole component with animation at some point (ie. loader).
3. Exception is throw for listener removal from not existing listener map which was cleared already on destroy.