### PR TITLE
Omit default HTML loop prop from LottieOptions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -42,16 +42,15 @@ export type LottieOptions = Omit<AnimationConfigWithData, "container"> & {
   onLoadedImages?: AnimationEventHandler | null;
   onDOMLoaded?: AnimationEventHandler | null;
   onDestroy?: AnimationEventHandler | null;
-} & React.HTMLProps<HTMLDivElement>;
+} & Omit<React.HTMLProps<HTMLDivElement>, 'loop'>;
 
 export type PartialLottieOptions = Omit<LottieOptions, "animationData"> & {
   animationData?: LottieOptions["animationData"];
 };
 
-export type LottieComponentProps = LottieOptions &
-  React.HTMLProps<HTMLDivElement> & {
-    interactivity?: Omit<InteractivityProps, "lottieObj">;
-  };
+export type LottieComponentProps = LottieOptions & {
+  interactivity?: Omit<InteractivityProps, "lottieObj">;
+};
 
 export type PartialLottieComponentProps = Omit<
   LottieComponentProps,


### PR DESCRIPTION
Typescript was trying to merge the HTML loop `boolean` prop with Lottie's `boolean | number` prop resulting in a prop type of `boolean` meaning a number cannot be passed to this prop

Related: https://github.com/Gamote/lottie-react/issues/30