### PR TITLE
fix: Typescript expose the RendererType from lottie-web

### DIFF
--- a/src/hooks/useLottie.tsx
+++ b/src/hooks/useLottie.tsx
@@ -3,6 +3,7 @@ import lottie, {
   AnimationItem,
   AnimationDirection,
   AnimationSegment,
+  RendererType,
 } from "lottie-web";
 import React, {
   CSSProperties,
@@ -18,8 +19,8 @@ import {
   PartialListener,
 } from "../types";
 
-const useLottie = (
-  props: LottieOptions,
+const useLottie = <T extends RendererType = "svg">(
+  props: LottieOptions<T>,
   style?: CSSProperties,
 ): { View: ReactElement } & LottieRefCurrentProps => {
   const {
@@ -174,7 +175,7 @@ const useLottie = (
     animationInstanceRef.current?.destroy();
 
     // Build the animation configuration
-    const config: AnimationConfigWithData = {
+    const config: AnimationConfigWithData<T> = {
       ...props,
       ...forcedConfigs,
       container: animationContainer.current,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,10 @@
-import {
+import type {
   AnimationConfigWithData,
   AnimationDirection,
   AnimationEventName,
   AnimationItem,
   AnimationSegment,
+  RendererType,
 } from "lottie-web";
 import React, {
   MutableRefObject,
@@ -34,8 +35,8 @@ export type LottieRefCurrentProps = {
 
 export type LottieRef = MutableRefObject<LottieRefCurrentProps | null>;
 
-export type LottieOptions = Omit<
-  AnimationConfigWithData,
+export type LottieOptions<T extends RendererType = "svg"> = Omit<
+  AnimationConfigWithData<T>,
   "container" | "animationData"
 > & {
   animationData: unknown;
@@ -50,7 +51,7 @@ export type LottieOptions = Omit<
   onLoadedImages?: AnimationEventHandler | null;
   onDOMLoaded?: AnimationEventHandler | null;
   onDestroy?: AnimationEventHandler | null;
-} & Omit<React.HTMLProps<HTMLDivElement>, 'loop'>;
+} & Omit<React.HTMLProps<HTMLDivElement>, "loop">;
 
 export type PartialLottieOptions = Omit<LottieOptions, "animationData"> & {
   animationData?: LottieOptions["animationData"];


### PR DESCRIPTION
To use the `canvas` or `html` renderer the `lottie-web` `RendererType` needs to be exposed as a Generic.

This issue was also seen in https://github.com/Gamote/lottie-react/issues/77.