### PR TITLE
feat: support alternative container via as prop

### DIFF
--- a/docs/components/Lottie/README.mdx
+++ b/docs/components/Lottie/README.mdx
@@ -171,6 +171,24 @@ const Example = () =>
 export default Example;
 ```
 
+### `as`
+
+React `ElementType` or `ComponentType` that replaces the default container `<div>` element.
+
+```jsx
+import Lottie from "lottie-react";
+import fancyLoadingAnimation from "./fancyLoading.json";
+
+const Example = () =>
+  <button>
+    <Lottie
+      as="span"
+      animationData={fancyLoadingAnimation}
+    />
+    Loading
+  </button>
+```
+
 ## Interaction methods
 
 These methods are designed to give you more control over the Lottie animation, and fill in the gaps left by the props:

--- a/src/hooks/useLottie.tsx
+++ b/src/hooks/useLottie.tsx
@@ -40,6 +40,8 @@ const useLottie = <T extends RendererType = "svg">(
     onDOMLoaded,
     onDestroy,
 
+    as: Container = "div",
+
     // Specified here to take them out from the 'rest'
     lottieRef,
     renderer,
@@ -320,7 +322,11 @@ const useLottie = <T extends RendererType = "svg">(
   /**
    * Build the animation view
    */
-  const View = <div style={style} ref={animationContainer} {...rest} />;
+  const View = React.createElement(Container, {
+    style,
+    ref: animationContainer,
+    ...rest,
+  });
 
   return {
     View,

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ import React, {
   AnimationEventHandler,
   ReactElement,
   RefObject,
+  ComponentType,
+  ElementType,
 } from "react";
 
 export type LottieRefCurrentProps = {
@@ -51,7 +53,8 @@ export type LottieOptions<T extends RendererType = "svg"> = Omit<
   onLoadedImages?: AnimationEventHandler | null;
   onDOMLoaded?: AnimationEventHandler | null;
   onDestroy?: AnimationEventHandler | null;
-} & Omit<React.HTMLProps<HTMLDivElement>, "loop">;
+  as?: ElementType | ComponentType;
+} & Omit<React.HTMLProps<HTMLDivElement>, "loop" | "as">;
 
 export type PartialLottieOptions = Omit<LottieOptions, "animationData"> & {
   animationData?: LottieOptions["animationData"];


### PR DESCRIPTION
## Summary

Provide a new prop `as` allowing container to be switched out to a user provided `React.ElementType` or `React.ComponentType`

## Related to

Related to #110

## How is this tested?


![image](https://github.com/Gamote/lottie-react/assets/8733840/da80cdab-1f3f-42c3-bbb4-3609a0a8e846)


Tested with the following code snippet (This is not included in this PR / documentation change)

```jsx
import React from "react";
import Lottie from "../../../src/components/Lottie";
import groovyWalkAnimation from "../../assets/groovyWalk.json";

const LottieAsExample = () => {
  return (
    <button>
      <Lottie
        animationData={groovyWalkAnimation}
        autoplay={true}
        as="span"
        style={{ display: 'inline-block', width: "2rem" }}
        data-testid="loading-graphic"
      />
      Loading
    </button>
  );
};

export default LottieAsExample;
```

![image](https://github.com/Gamote/lottie-react/assets/8733840/a8ebdfa2-0589-4c11-931a-d8bcabda3d71)
