### PR TITLE
fix: add exports field and remove browser field to fix Rolldown/Vite 8 interop

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,16 @@
   "author": "David Gamote",
   "main": "build/index.js",
   "module": "build/index.es.js",
-  "browser": "build/index.umd.js",
   "types": "build/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "import": "./build/index.es.js",
+      "require": "./build/index.js",
+      "default": "./build/index.es.js"
+    },
+    "./package.json": "./package.json"
+  },
   "style": "build/index.css",
   "files": [
     "/build"


### PR DESCRIPTION
## Summary

Modern bundlers like Vite 8 (Rolldown-based) fail to resolve the correct ESM entry for `lottie-react` because the package lacks an `exports` field and exposes a `browser` field pointing to the UMD build.

Vite's default `resolve.mainFields` order is `['browser', 'module', ...]`, so it resolves to `build/index.umd.js` (UMD) instead of `build/index.es.js` (ESM). Rolldown's CJS interop then wraps the UMD default export as `{ default: { default: Component } }`, which breaks `React.lazy()` and any other code expecting a direct default export. See issue #130

## Changes

- Add `exports` field with conditional exports (`import`, `require`, `types`, `default`)
- Remove `browser` field (pointed to UMD, which is no longer needed by modern bundlers)

```diff
  "main": "build/index.js",
  "module": "build/index.es.js",
- "browser": "build/index.umd.js",
  "types": "build/index.d.ts",
+ "exports": {
+   ".": {
+     "types": "./build/index.d.ts",
+     "import": "./build/index.es.js",
+     "require": "./build/index.js",
+     "default": "./build/index.es.js"
+   },
+   "./package.json": "./package.json"
+ },
```

## Why

| Scenario | Before (UMD resolved) | After (ESM resolved) |
|---|---|---|
| `import Lottie from "lottie-react"` in Vite 8 / Rolldown | `{ default: { default: Component } }` — broken | `{ default: Component }` — correct |
| `import Lottie from "lottie-react"` in Vite 6 / Rollup | Works (Rollup handles UMD interop) | Works (ESM direct) |
| `import Lottie from "lottie-react"` in webpack 5 | Works | Works |
| `const Lottie = require("lottie-react")` in Node.js | Works (CJS via `main`) | Works (CJS via `require` condition) |

## Context

- Vite 8 migration guide: [Consistent CommonJS Interop](https://vite.dev/guide/migration.html#consistent-commonjs-interop)
- Rolldown CJS bundling docs: [Ambiguous default import from CJS modules](https://rolldown.rs/in-depth/bundling-cjs#ambiguous-default-import-from-cjs-modules)
- Node.js `exports` docs: [Package entry points](https://nodejs.org/api/packages.html#package-entry-points)
