### PR TITLE
feat: add path support to LottieOptions

### DIFF
--- a/src/hooks/useLottie.tsx
+++ b/src/hooks/useLottie.tsx
@@ -25,6 +25,7 @@ const useLottie = <T extends RendererType = "svg">(
 ): { View: ReactElement } & LottieRefCurrentProps => {
   const {
     animationData,
+    path,
     loop,
     autoplay,
     initialSegment,
@@ -202,7 +203,7 @@ const useLottie = <T extends RendererType = "svg">(
     // Clean up on unmount
     return () => onUnmount?.();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animationData, loop]);
+  }, [animationData, path, loop]);
 
   // Update the autoplay state
   useEffect(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,6 @@ export type LottieOptions<T extends RendererType = "svg"> = Omit<
   AnimationConfigWithData<T>,
   "container" | "animationData"
 > & {
-  animationData: unknown;
   lottieRef?: LottieRef;
   onComplete?: AnimationEventCallback<
     AnimationEvents[AnimationEventName]
@@ -68,10 +67,18 @@ export type LottieOptions<T extends RendererType = "svg"> = Omit<
   onDestroy?: AnimationEventCallback<
     AnimationEvents[AnimationEventName]
   > | null;
-} & Omit<React.HTMLProps<HTMLDivElement>, "loop">;
+} & Omit<React.HTMLProps<HTMLDivElement>, "loop"> &
+  (
+    | { animationData: unknown; path?: never }
+    | { path: string; animationData?: never }
+  );
 
-export type PartialLottieOptions = Omit<LottieOptions, "animationData"> & {
+export type PartialLottieOptions = Omit<
+  LottieOptions,
+  "animationData" | "path"
+> & {
   animationData?: LottieOptions["animationData"];
+  path?: string;
 };
 
 // Interactivity


### PR DESCRIPTION
**Description**

`lottie-web` supports loading animations from a URL via the path option, but `LottieOptions` was typed only around `AnimationConfigWithData`, so passing `path` required casting through `unknown`. With this change, `LottieOptions` now accepts either `animationData` or `path` . The path approach lets bundlers emit the JSON as a separate asset instead of inlining it. For larger animations this is a meaningful bundle size improvement.