### PR TITLE
fix(interactions): measure by hand when the scroll timeline's scroller cannot scroll

### DIFF
--- a/src/interactions/lottieScrollScrub.test.tsx
+++ b/src/interactions/lottieScrollScrub.test.tsx
@@ -270,6 +270,74 @@ it("warns once and measures by hand when the timeline is inactive", () => {
   expect(inactive).toHaveLength(1);
 });
 
+it("measures by hand when the timeline's scroller cannot scroll", () => {
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const scrub = mountScrub();
+  const height = window.innerHeight;
+  /* A quarter of the way through the journey by geometry: the leading edge
+     sits a quarter of the span above the viewport's far end. */
+  vi.spyOn(scrub.root, "getBoundingClientRect").mockReturnValue(
+    new DOMRect(0, height - (height + 200) / 4, 100, 200),
+  );
+  /* `body` with `overflow-x: hidden` is a scroll container that never
+     scrolls; happy-dom's zero extents say exactly that. */
+  timelines?.last().setSource(document.body);
+
+  scrub.enter();
+  scrub.drive(50);
+
+  expect(scrub.frame()).toBeCloseTo(15, 0);
+  expect(warn).not.toHaveBeenCalled();
+});
+
+it("keeps the timeline when its scroller really scrolls", () => {
+  const scrub = mountScrub();
+  const scroller = document.createElement("div");
+  vi.spyOn(scroller, "scrollHeight", "get").mockReturnValue(1000);
+  vi.spyOn(scroller, "clientHeight", "get").mockReturnValue(300);
+  timelines?.last().setSource(scroller);
+
+  scrub.enter();
+  scrub.drive(50);
+
+  expect(scrub.frame()).toBeCloseTo(30, 0);
+});
+
+it("checks the scroller again on each entry", () => {
+  const scrub = mountScrub();
+  const height = window.innerHeight;
+  vi.spyOn(scrub.root, "getBoundingClientRect").mockReturnValue(
+    new DOMRect(0, height - (height + 200) / 4, 100, 200),
+  );
+  const scroller = document.createElement("div");
+  const extent = vi.spyOn(scroller, "scrollHeight", "get").mockReturnValue(0);
+  vi.spyOn(scroller, "clientHeight", "get").mockReturnValue(0);
+  timelines?.last().setSource(scroller);
+
+  scrub.enter();
+  scrub.drive(50);
+  expect(scrub.frame()).toBeCloseTo(15, 0);
+
+  scrub.exit();
+  extent.mockReturnValue(1000);
+  scrub.enter();
+  scrub.drive(50);
+  expect(scrub.frame()).toBeCloseTo(30, 0);
+});
+
+it("checks the inline extents when the journey runs inline", () => {
+  const scrub = mountScrub({ axis: "inline" });
+  const scroller = document.createElement("div");
+  vi.spyOn(scroller, "scrollWidth", "get").mockReturnValue(1000);
+  vi.spyOn(scroller, "clientWidth", "get").mockReturnValue(300);
+  timelines?.last().setSource(scroller);
+
+  scrub.enter();
+  scrub.drive(50);
+
+  expect(scrub.frame()).toBeCloseTo(30, 0);
+});
+
 it("shrugs at options it does not recognise and scrubs the whole journey", () => {
   io = installIntersectionObserverStub();
   timelines = installViewTimelineStub();

--- a/src/interactions/lottieScrollScrub.ts
+++ b/src/interactions/lottieScrollScrub.ts
@@ -51,6 +51,34 @@ function isScrubOptions(value: unknown): value is LottieScrollScrubOptions {
   return !("onRangeLeave" in value && typeof value.onRangeLeave !== "function");
 }
 
+/** Whether an element has anything to scroll along the axis right now. */
+function canScrollAlong(element: Element, axis: "block" | "inline"): boolean {
+  return axis === "inline"
+    ? element.scrollWidth > element.clientWidth
+    : element.scrollHeight > element.clientHeight;
+}
+
+/*
+ * A view timeline binds to the nearest ancestor that is a scroll container,
+ * and any non-visible overflow makes an element one whether or not it ever
+ * scrolls: `overflow-x: hidden` on `body` makes `body` the scroller while the
+ * viewport is what moves, and the timeline then holds one position. So the
+ * timeline is trusted only when its scroller is the document's own, whose
+ * extents are the viewport's and not to be second-guessed, or when it can
+ * scroll along the axis. A `null` scroller is left to the inactive path,
+ * which reads `currentTime`.
+ */
+function timelineIsUsable(
+  timeline: ViewTimeline,
+  axis: "block" | "inline",
+): boolean {
+  const source = timeline.source;
+  if (source === null || source === document.scrollingElement) {
+    return true;
+  }
+  return canScrollAlong(source, axis);
+}
+
 function attachScrollScrub(
   context: LottieInteractionContext,
   raw: unknown,
@@ -62,6 +90,7 @@ function attachScrollScrub(
   let observer: IntersectionObserver | null = null;
   let observedRoot: HTMLElement | null = null;
   let timeline: ViewTimeline | null = null;
+  let useTimeline = false;
   let frameHandle: number | null = null;
   let scrubbing = false;
   let gestureStarted = false;
@@ -69,7 +98,7 @@ function attachScrollScrub(
   let warnedInactive = false;
 
   const readProgress = (root: HTMLElement): number => {
-    if (timeline !== null) {
+    if (useTimeline && timeline !== null) {
       const time = timeline.currentTime;
       if (typeof time === "number") {
         return Math.min(Math.max(time / 100, 0), 1);
@@ -147,6 +176,13 @@ function attachScrollScrub(
     }
     scrubbing = true;
     previousBand = null;
+    /*
+     * Decided once per entry rather than per frame: an entry is when layout
+     * exists to be read, and reading extents every frame would put the layout
+     * cost back on the platform path that exists to avoid it. A scroller that
+     * only later grows something to scroll is picked up on the next entry.
+     */
+    useTimeline = timeline !== null && timelineIsUsable(timeline, axis);
     if (context.lottie.state !== LottieState.loading) {
       gestureStarted = true;
       context.lottie.scrubStart();
@@ -188,6 +224,7 @@ function attachScrollScrub(
     observer?.disconnect();
     observer = null;
     timeline = null;
+    useTimeline = false;
     observedRoot = root;
     if (root === null) {
       return;
@@ -246,9 +283,10 @@ function attachScrollScrub(
  * </LottieInteractions>
  * ```
  *
- * Progress is the platform's own scroll timeline where the browser has one,
- * and the same arithmetic measured by hand where it does not; the numbers
- * agree by construction. While the animation is out of view nothing samples
+ * Progress is the platform's own scroll timeline where the browser has one
+ * and its scroller is one that scrolls, and the same arithmetic measured by
+ * hand against the viewport where it does not; the numbers agree by
+ * construction. While the animation is out of view nothing samples
  * at all, and playback state is held by the scrub gesture, so whatever was
  * true before the scrub is restored when it leaves.
  */

--- a/src/test/installViewTimelineStub.ts
+++ b/src/test/installViewTimelineStub.ts
@@ -10,6 +10,12 @@ import { vi } from "vitest";
 export class StubbedViewTimeline {
   readonly subject: Element;
   readonly axis: string;
+  /**
+   * The scroller the timeline reports as driving it. A real one derives it
+   * from the subject's ancestors; the stub answers the document's own scroller
+   * unless a test says otherwise, which is what a plain page produces.
+   */
+  source: Element | null;
   private percent: number | null = null;
 
   constructor(options?: ViewTimelineOptions) {
@@ -19,6 +25,7 @@ export class StubbedViewTimeline {
     }
     this.subject = subject;
     this.axis = options?.axis ?? "block";
+    this.source = document.scrollingElement;
     installed?.instances.push(this);
   }
 
@@ -41,6 +48,11 @@ export class StubbedViewTimeline {
   setNumeric(percent: number): void {
     this.percent = percent;
     this.numeric = true;
+  }
+
+  /** Makes the timeline report another element, or none, as its scroller. */
+  setSource(element: Element | null): void {
+    this.source = element;
   }
 }
 


### PR DESCRIPTION
## What

`lottieScrollScrub` drives the playhead from a `ViewTimeline` on the animation's root. A view timeline binds to the nearest ancestor that is a scroll container, and any non-visible overflow makes an element one whether or not it ever scrolls. With `overflow-x: hidden` on `html, body` (a common rule, and create-next-app's default stylesheet), `body` becomes the timeline's scroller while the viewport is what moves: the timeline stays active at one position and a page scrub stands still, with no warning.

The scrub now trusts the timeline only when its scroller is the document's own (`document.scrollingElement`) or can scroll along the chosen axis, decided once per visibility entry so the platform path stays free of layout reads; otherwise it measures the root against the viewport by hand, the same arithmetic the timeline would have produced. A scrolling `div` is unaffected.

## Verified

- Four new tests, written red-first (the two non-scrolling-scroller cases fail on `main`): a non-scrolling scroller falls back to geometry with no warning; a real scroller keeps the timeline; the check reruns on each entry; the inline axis checks inline extents. The `ViewTimeline` test stub gains `source` and `setSource`.
- `pnpm check` green: 478 tests, coverage 100 / 97.43 / 100 / 100, budgets under, 34 pages rendered.
- Real browser (Playwright, Chromium), the packed build installed into a Next.js 16 Turbopack app **with** `html, body { overflow-x: hidden }`: a page scrub that sat at one frame on 3.0.0 now runs 0 → 180 linearly across the root's journey, on both the component path (tall `<Lottie>` root, sticky `<LottieDisplay>`) and the hook path (`setRootRef` on a section). Without the rule, behaviour is identical to before.
