### PR TITLE
docs: add the cursor and recolouring recipes and sharpen four pages

### DIFF
--- a/src/interactions/types.ts
+++ b/src/interactions/types.ts
@@ -10,7 +10,11 @@ import type { LottieInstance } from "../animation/types.js";
  * at the moment an event fires without the behaviour ever re-attaching.
  */
 export interface LottieInteractionContext {
-  /** The animation: values, commands, `subscribe`, `root`. Read fresh each use. */
+  /**
+   * The animation: values, commands, `subscribe`, `root`. Read it through the
+   * context on every use: it answers the current animation each time, and a
+   * copy taken once keeps that moment's values, `root` included.
+   */
   readonly lottie: LottieInstance;
   /** The descriptor's options as they are right now. */
   options: () => unknown;

--- a/website/content/docs/(v3)/animation/styling.mdx
+++ b/website/content/docs/(v3)/animation/styling.mdx
@@ -12,6 +12,16 @@ Every default style ships at zero specificity, so any rule of yours beats any de
 `className`, `style`, `id`, `data-*`, `aria-*` and DOM event props all land on the element `<Lottie>` renders.
 Utility classes, CSS modules and `styled(Lottie)` work the way they do on a `<div>`.
 
+## Recolouring
+
+The engine draws fills and strokes as attributes on the SVG, and CSS beats attributes, so a rule on the animation's element recolours it.
+With `currentColor`, the surrounding text colour becomes the icon's colour:
+
+<Example name="styling/recolour" />
+
+In plain CSS the same rule is `.icon svg path { fill: currentColor; stroke: currentColor }`; it sets both because artwork draws with fills, with strokes, or with both, as this file does.
+This route is for the svg renderer and solid colours; to recolour for every renderer, gradients included, rewrite the colours in the animation itself and pass the object to `src`, which reloads when its content changes.
+
 ## Layered CSS
 
 When your styles live in cascade layers, declare the library's layer first.

--- a/website/content/docs/(v3)/animation/the-instance.mdx
+++ b/website/content/docs/(v3)/animation/the-instance.mdx
@@ -40,6 +40,7 @@ const lottie = useLottie({
 `subscribe` on the instance attaches one handler at a time and returns the unsubscribe, for anything that mounts later.
 
 The current frame is a subscription, not a value: it changes sixty times a second, faster than a component should re-render.
+The frame it reports counts from the start of the playable range, so after `playSegments` it runs from 0 to `playableFrames`, the way `playableFrames` follows the range.
 Subscribe to `frame`, and write the number where it goes without touching React state, as the readout above does: per-frame state updates re-render sixty times a second.
 
 ## The escape hatch

--- a/website/content/docs/(v3)/examples/basics.mdx
+++ b/website/content/docs/(v3)/examples/basics.mdx
@@ -13,6 +13,10 @@ Every example is complete: take the code under it whole.
 
 <Example name="rendering/sizing" />
 
+## Recolour it
+
+<Example name="styling/recolour" />
+
 ## Drive it from state
 
 <Example name="driving/speed-and-direction" />

--- a/website/content/docs/(v3)/examples/interactions.mdx
+++ b/website/content/docs/(v3)/examples/interactions.mdx
@@ -15,6 +15,14 @@ Each press restarts from the top: seek, then play:
 
 <Example name="recipes/play-on-click" />
 
+## Follow the cursor
+
+The pointer's horizontal position across the element sets the frame: move left and right to scrub, and leaving rewinds:
+
+<Example name="recipes/cursor-follow" />
+
+`seek` clamps what it is given, so the edges need no guard of their own.
+
 ## Segment on state
 
 The playing range follows React state, so anything that sets the state steers the animation:

--- a/website/content/docs/(v3)/get-started/installation.mdx
+++ b/website/content/docs/(v3)/get-started/installation.mdx
@@ -16,6 +16,7 @@ npm i lottie-react
 
 Import it anywhere React renders, the server included.
 Nothing touches the browser until an animation mounts, so server rendering needs no dynamic import and no client-only workaround.
+Under React Server Components, `<Lottie>` goes in a file marked `"use client"`, like any component that uses hooks; that file still renders on the server.
 
 ## If your CSS lives in cascade layers
 

--- a/website/content/docs/(v3)/interactions/writing-your-own.mdx
+++ b/website/content/docs/(v3)/interactions/writing-your-own.mdx
@@ -20,8 +20,8 @@ The context carries four things:
 - `onChange(listener)`: fires when the root arrives, the values move, or the options change; re-check what you armed against and return early when nothing you use moved.
 - `memory`: scratch that survives an option change, for state that must outlive a re-attach.
 
-The factory above arms through `onChange` because `root` can arrive after `attach` runs.
+The factory above arms through `onChange` because `root` can arrive after `attach` runs, and it reads `context.lottie` each time rather than copying it once: the context hands out the current animation on every read, and a copy taken at attach time keeps the `root` of that moment, usually `null`.
 
 `LottieInteraction` and `LottieInteractionContext` are exported, so a factory of yours typechecks against the same contract the shipped ones use.
 
-Not everything needs a factory: when one element's own events are enough, a plain handler is simpler, and the gallery's [interaction recipes](/docs/examples/interactions) show hover, click and state handled that way.
+Not everything needs a factory: when one element's own events are enough, a plain handler is simpler, and the gallery's [interaction recipes](/docs/examples/interactions) show hover, click, cursor and state handled that way.

--- a/website/content/docs/(v3)/migration.mdx
+++ b/website/content/docs/(v3)/migration.mdx
@@ -107,7 +107,7 @@ return <div ref={lottie.setDisplayRef} style={{ height: 300 }} />;
 | --- | --- |
 | `mode: "scroll"` with a `seek` action | `lottieScrollScrub({ range })` |
 | `visibility: [0.4, 0.9]` | `range: [0.4, 0.9]` |
-| `mode: "cursor"` | no shipped factory: [write one](/docs/interactions/writing-your-own) against the same contract |
+| `mode: "cursor"` | the [cursor recipe](/docs/examples/interactions#follow-the-cursor): a pointer handler on the instance |
 | chained actions | no equivalent |
 
 ## Packaging

--- a/website/src/components/examples/interactions/custom-factory.tsx
+++ b/website/src/components/examples/interactions/custom-factory.tsx
@@ -7,13 +7,13 @@ import {
 function playWhilePressed(): LottieInteraction {
   return {
     options: undefined,
-    attach: ({ lottie, onChange }) => {
+    attach: (context) => {
       let detach: (() => void) | undefined;
       const arm = () => {
-        const root = lottie.root;
+        const root = context.lottie.root;
         if (root === null || detach !== undefined) return;
-        const down = () => lottie.play();
-        const up = () => lottie.pause();
+        const down = () => context.lottie.play();
+        const up = () => context.lottie.pause();
         root.addEventListener("pointerdown", down);
         root.addEventListener("pointerup", up);
         detach = () => {
@@ -22,7 +22,7 @@ function playWhilePressed(): LottieInteraction {
         };
       };
       arm();
-      const stop = onChange(arm);
+      const stop = context.onChange(arm);
       return () => {
         stop();
         detach?.();

--- a/website/src/components/examples/recipes/cursor-follow.tsx
+++ b/website/src/components/examples/recipes/cursor-follow.tsx
@@ -1,0 +1,19 @@
+import { LottieDisplay, useLottie } from "lottie-react";
+
+export function CursorFollow() {
+  const lottie = useLottie({ src: "/anim.json" });
+
+  return (
+    <LottieDisplay
+      lottie={lottie}
+      className="size-48 touch-none"
+      onPointerMove={(event) => {
+        const box = event.currentTarget.getBoundingClientRect();
+        lottie.seek({
+          percent: ((event.clientX - box.left) / box.width) * 100,
+        });
+      }}
+      onPointerLeave={() => lottie.seek(0)}
+    />
+  );
+}

--- a/website/src/components/examples/styling/recolour.tsx
+++ b/website/src/components/examples/styling/recolour.tsx
@@ -1,0 +1,12 @@
+import { Lottie } from "lottie-react";
+
+export function Recolour() {
+  return (
+    <Lottie
+      src="/anim.json"
+      autoplay
+      loop
+      className="size-32 text-pink-500 [&_svg_path]:fill-current [&_svg_path]:stroke-current"
+    />
+  );
+}


### PR DESCRIPTION
## What

- **Follow the cursor**, a new recipe in the interactions gallery: the pointer's horizontal position sets the frame through `seek({ percent })`, leaving rewinds. The migration guide's `mode: "cursor"` row now points at it, and "Writing your own" lists cursor among the plain-handler recipes.
- **Recolouring**, a new section on the styling page with a live example (`fill` and `stroke` to `currentColor` on the animation's element, since artwork draws with either or both) and one sentence on recolouring the data itself for every renderer; the Basics gallery reuses the example.
- **The custom-factory example** read a copy of `context.lottie` taken at attach time, so on a prerendered page its `root` stayed `null` and the "play while pressed" behaviour never armed (it worked after a client-side navigation only because the root happened to be there already). It now reads the context on every use, the page says why, and the JSDoc of `LottieInteractionContext.lottie` carries the same note.
- Installation: where `<Lottie>` goes under React Server Components (a `"use client"` file, which still renders on the server). The instance page: the reported frame counts from the start of the playable range.

## Verified

- Website check green (examples typecheck, 35 pages prerendered, `assert-rendered` clean); Biome clean.
- On the built site in a real browser: the cursor example follows the pointer and rewinds on leave; the recolour example's three paths (two gradient strokes, one gradient fill) all compute to the text colour; the custom-factory example now registers its listener and plays on a direct load.
