### PR TITLE
feat: mark the components, hooks, factories and configureLottie as client modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ Import order is enforced by Biome's `organizeImports` assist and is auto-fixable
 
 Relative imports carry a `.js` extension even though the file on disk is `.ts` or `.tsx`: the extension names the emitted output, not the source. This follows from `moduleResolution: nodenext`, which checks specifiers the way Node resolves them rather than the way a bundler would, so a missing extension is a typecheck error. The strictness is deliberate, because this package renders on the server and an import only a bundler can resolve is a defect that `bundler` resolution cannot see.
 
+A public module that only works in the browser starts with `"use client";`: every component, every hook, the interaction factories and `configureLottie`. Under React Server Components that line is what lets a server component import `<Lottie>` directly instead of evaluating the module, and what makes a server-side call of `configureLottie` fail at build time rather than configure a copy the browser never sees. The barrel and the vocabulary maps in `types.ts` stay unmarked, because the barrel must be evaluated to re-export and a server component may read `LottieDirection.reverse`. tsdown keeps the directive at the top of the emitted file, so the source line is the whole mechanism.
+
 ### Components
 
 Feature code decomposes into small components with typed props and a single visual responsibility, kept as sibling files in the folder they belong to. Hooks own state and side effects; components render what they are given.

--- a/src/animation/Lottie.tsx
+++ b/src/animation/Lottie.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 import {
   createLottieComponent,

--- a/src/animation/LottieDisplay.tsx
+++ b/src/animation/LottieDisplay.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type Ref, useMemo } from "react";
 import { mergeRefs } from "../utils/mergeRefs.js";
 import { polymorphicForwardRef } from "./polymorphicForwardRef.js";

--- a/src/animation/LottieLight.tsx
+++ b/src/animation/LottieLight.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 import {
   createLottieComponent,

--- a/src/animation/LottieSvg.tsx
+++ b/src/animation/LottieSvg.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 import {
   createLottieComponent,

--- a/src/animation/configureLottie.ts
+++ b/src/animation/configureLottie.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { LottiePlayer } from "lottie-web";
 
 /** What {@link configureLottie} can be told. */

--- a/src/animation/useLottie.ts
+++ b/src/animation/useLottie.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import lottie from "lottie-web";
 import { type LottieEngine, LottieEngineName } from "./configureLottie.js";
 import type { LottieInstance, LottieRenderer } from "./types.js";

--- a/src/animation/useLottieInstance.ts
+++ b/src/animation/useLottieInstance.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { useContext } from "react";
 import { LottieInstanceContext } from "./LottieInstanceContext.js";
 import type { LottieInstance } from "./types.js";

--- a/src/animation/useLottieLight.ts
+++ b/src/animation/useLottieLight.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import lottieLight from "lottie-web/build/player/lottie_light.js";
 import { type LottieEngine, LottieEngineName } from "./configureLottie.js";
 import type { LottieInstance, LottieRenderer } from "./types.js";

--- a/src/animation/useLottieSvg.ts
+++ b/src/animation/useLottieSvg.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import lottieSvg from "lottie-web/build/player/lottie_svg.js";
 import { type LottieEngine, LottieEngineName } from "./configureLottie.js";
 import type { LottieInstance, LottieRenderer } from "./types.js";

--- a/src/controls/LottieControls.tsx
+++ b/src/controls/LottieControls.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { forwardRef, useCallback, useRef } from "react";
 import { renderStyledElement } from "../animation/renderStyledElement.js";
 import {

--- a/src/interactions/LottieInteractions.tsx
+++ b/src/interactions/LottieInteractions.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type ReactNode, useContext, useState } from "react";
 import { LottieInstanceContext } from "../animation/LottieInstanceContext.js";
 import {

--- a/src/interactions/lottieInView.ts
+++ b/src/interactions/lottieInView.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import { LottieState } from "../animation/types.js";
 import type { LottieInteraction, LottieInteractionContext } from "./types.js";
 

--- a/src/interactions/lottieScrollScrub.ts
+++ b/src/interactions/lottieScrollScrub.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { LottieInstance } from "../animation/types.js";
 import { LottieState } from "../animation/types.js";
 import { bandEdges, bandProgress, coverProgress } from "./coverProgress.js";

--- a/src/interactions/useLottieInteractions.ts
+++ b/src/interactions/useLottieInteractions.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import type { LottieInstance } from "../animation/types.js";
 import type { LottieInteraction } from "./types.js";
 import {

--- a/src/overlays/LottieError.tsx
+++ b/src/overlays/LottieError.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { forwardRef, type ReactNode } from "react";
 import { renderStyledElement } from "../animation/renderStyledElement.js";
 import {

--- a/src/overlays/LottieLoading.tsx
+++ b/src/overlays/LottieLoading.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { forwardRef, type ReactNode } from "react";
 import { renderStyledElement } from "../animation/renderStyledElement.js";
 import {

--- a/website/content/docs/(v3)/animation/configuring-the-engine.mdx
+++ b/website/content/docs/(v3)/animation/configuring-the-engine.mdx
@@ -16,7 +16,8 @@ configureLottie({ idPrefix: "crm", quality: "low" });
 Set it once, at startup, before animations load.
 It takes effect at once on every engine that has loaded an animation, and on the others when they first do, and it reaches what is already on screen: element IDs for everything the engines build from then on, and the drawing quality of every animation on them.
 A field left out keeps its value.
-The settings are held for the life of the page, or of the server process, so it is a one-time setup, not something to call per render or per request.
+The settings are held for the life of the page, so it is a one-time setup, not something to call per render.
+Call it from client code, where the animations run: under React Server Components it is client code, and a call from a server component fails at build time rather than configuring a copy the browser never sees.
 
 ## Element IDs
 

--- a/website/content/docs/(v3)/get-started/installation.mdx
+++ b/website/content/docs/(v3)/get-started/installation.mdx
@@ -16,7 +16,7 @@ npm i lottie-react
 
 Import it anywhere React renders, the server included.
 Nothing touches the browser until an animation mounts, so server rendering needs no dynamic import and no client-only workaround.
-Under React Server Components, `<Lottie>` goes in a file marked `"use client"`, like any component that uses hooks; that file still renders on the server.
+Under React Server Components the components and hooks mark themselves as client code, so a server component can import `<Lottie>` directly and it still renders on the server; `configureLottie`, like the hooks, is called from client code, where the animations run.
 
 ## If your CSS lives in cascade layers
 


### PR DESCRIPTION
## What

Under React Server Components a module that only works in the browser says so with `"use client"`, and a server component that imports it receives a client reference instead of evaluating it. Without the line, `import { Lottie } from "lottie-react"` in a server component made the Next build fail at page-data collection with `TypeError: createContext is not a function` (React's server build has no `createContext`, and our context modules evaluate it when the barrel is imported); the only route was the consumer's own `"use client"` file.

Now every component, every hook, the interaction factories and `configureLottie` start with the directive (16 modules). The barrel and the vocabulary maps stay unmarked: the barrel must be evaluated to re-export, and a server component may read `LottieDirection.reverse`. The rule is recorded in `CLAUDE.md` under "Modules and exports". Docs: the installation page says a server component can import the components directly, and that `configureLottie`, like the hooks, is called from client code; the configuring page says a server-side call fails at build time rather than configuring a copy the browser never sees.

## Verified

- tsdown keeps a top-of-file directive in both the ESM and the CJS output of exactly that file (probed and reverted before the change).
- Packed build in a Next.js 16 Turbopack app: a **server component** importing `Lottie` directly builds, prerenders (element in the HTML), hydrates and plays; a server component calling `configureLottie` fails at build time with React's message ("Attempted to call configureLottie() from the server but configureLottie is on the client…"); client-component pages unchanged.
- No directive warnings from Vite 8 (rolldown, our own website build) or esbuild (size-limit); Rollup-based bundlers (Vite 5 to 7) print their usual module-level-directive notice and continue, as for every RSC-ready library. Sizes unchanged.
- `pnpm check` green: 488 tests, coverage 100 / 97.46 / 100 / 100, 36 pages rendered.
