### PR TITLE
chore: release 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Lottie animations in React: one component for the easy path, the whole engine when you need control.",
   "keywords": [
     "lottie",


### PR DESCRIPTION
Version bump only. 3.1.0 carries, since 3.0.0: `configureLottie` with element IDs prefixed by default and the widened `rendererSettings` types (#137), the client-module directive on the public browser-only modules (#138), the scroll scrub under `overflow-x: hidden` (#134), the live `context.lottie` for interaction factories (#136), and the docs pass (#135). Gate green at this tree (488 tests, coverage 100 / 97.46 / 100 / 100, 36 pages); `pnpm check:package` loads all 20 exports through `require()` and native ESM.

After the merge: tag `v3.1.0` on the merge commit, publish, GitHub release, website deploy.
