### PR TITLE
fix: return a ref cleanup only when a merged ref returned one, so React 18 stays silent

### DIFF
--- a/src/animation/Lottie.test.tsx
+++ b/src/animation/Lottie.test.tsx
@@ -461,3 +461,33 @@ it("hands the element it renders to the animation as its root", () => {
   expect(root()?.className).toBe(lottieRootClass);
   expect(root()).not.toBe(only(`.${lottieDisplayClass}`));
 });
+
+/*
+ * React 18 reports a ref callback that returns a function, and the merged ref
+ * on the rendered element is where this library could. The runner does not
+ * fail on console output by itself, so silence has to be asserted for the
+ * React 18 lane to be able to go red.
+ */
+it("prints nothing to the console across a mount and unmount", () => {
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+  const view = render(<Lottie src={ANIMATION} />);
+  flushLoad();
+  view.unmount();
+
+  expect(error).not.toHaveBeenCalled();
+});
+
+it("prints nothing when the display is placed among children", () => {
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+  const view = render(
+    <Lottie src={ANIMATION}>
+      <LottieDisplay />
+    </Lottie>,
+  );
+  flushLoad();
+  view.unmount();
+
+  expect(error).not.toHaveBeenCalled();
+});

--- a/src/utils/mergeRefs.test.ts
+++ b/src/utils/mergeRefs.test.ts
@@ -4,10 +4,10 @@ import { mergeRefs } from "./mergeRefs.js";
 
 /*
  * React 18 and React 19 tear a ref down differently, and this library promises
- * both. Only one of the two paths can be exercised by rendering, because only
- * one React is installed, so they are driven directly here instead: calling the
- * merged callback with `null` is what React 18 does, and calling the function it
- * returns is what React 19 does.
+ * both. A render exercises only the installed React's path, so both are driven
+ * directly here: calling the merged callback with `null` is what React 18
+ * always does and what React 19 does when nothing was returned; calling the
+ * function it returns is what React 19 does when one was.
  */
 
 it("writes the element to every ref it was given", () => {
@@ -24,14 +24,37 @@ it("writes the element to every ref it was given", () => {
 it("ignores the refs that are not there", () => {
   const object = createRef<HTMLDivElement>();
   const node = document.createElement("div");
+  const merged = mergeRefs(undefined, object, null);
 
-  const teardown = mergeRefs(undefined, object, null)(node);
-  teardown?.();
+  merged(node);
+  merged(null);
 
   expect(object.current).toBeNull();
 });
 
-it("clears everything when React 18 calls it with null", () => {
+it("ignores the refs that are not there on the teardown it returned", () => {
+  const object = createRef<HTMLDivElement>();
+  const cleanup = vi.fn();
+  const withCleanup = vi.fn(() => cleanup);
+  const node = document.createElement("div");
+
+  const teardown = mergeRefs(undefined, object, null, withCleanup)(node);
+  teardown?.();
+
+  expect(object.current).toBeNull();
+  expect(cleanup).toHaveBeenCalledTimes(1);
+});
+
+it("returns nothing when no ref returned a cleanup, so React 18 has nothing to report", () => {
+  const object = createRef<HTMLDivElement>();
+  const callback = vi.fn();
+
+  expect(
+    mergeRefs(object, callback)(document.createElement("div")),
+  ).toBeUndefined();
+});
+
+it("clears everything when React calls it with null", () => {
   const object = createRef<HTMLDivElement>();
   const callback = vi.fn();
   const node = document.createElement("div");
@@ -47,13 +70,16 @@ it("clears everything when React 18 calls it with null", () => {
 it("clears everything when React 19 runs the cleanup it returned", () => {
   const object = createRef<HTMLDivElement>();
   const callback = vi.fn();
+  const cleanup = vi.fn();
+  const withCleanup = vi.fn(() => cleanup);
   const node = document.createElement("div");
 
-  const teardown = mergeRefs(object, callback)(node);
+  const teardown = mergeRefs(object, callback, withCleanup)(node);
   teardown?.();
 
   expect(object.current).toBeNull();
   expect(callback).toHaveBeenLastCalledWith(null);
+  expect(cleanup).toHaveBeenCalledTimes(1);
 });
 
 it("runs a ref's own cleanup rather than calling it with null", () => {

--- a/src/utils/mergeRefs.ts
+++ b/src/utils/mergeRefs.ts
@@ -6,20 +6,25 @@ import type { Ref, RefCallback } from "react";
  * An element has a single `ref` slot, so any element that both this library and
  * the person using it want a handle on needs one callback that feeds both.
  *
- * Teardown is the part that is not boilerplate, because the two supported React
- * versions differ. React 19 treats a function returned from a ref callback as
- * its cleanup and then never calls that ref with `null`, while React 18
- * discards the return and calls with `null`. So each ref gets its own cleanup
- * where it returned one and a `null` call where it did not, and the combined
- * teardown is returned for React 19 to run. React 18 ignores it and calls this
- * callback with `null` instead, which does the same work.
+ * Teardown is where the two supported React versions differ. React 19 treats a
+ * function returned from a ref callback as its cleanup and never calls that ref
+ * with `null`; React 18 always calls with `null` and, in development, reports a
+ * returned function. So a combined teardown is returned only when a ref returned
+ * a cleanup of its own, since that ref must be torn down by it rather than by a
+ * `null` call. Otherwise nothing is returned and both versions call this
+ * callback with `null`, which clears every ref.
  */
 export function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
   return (node) => {
+    let returned = false;
     const teardowns = refs.map((ref) => {
       if (typeof ref === "function") {
         const cleanup = ref(node);
-        return typeof cleanup === "function" ? cleanup : () => ref(null);
+        if (typeof cleanup === "function") {
+          returned = true;
+          return cleanup;
+        }
+        return () => ref(null);
       }
 
       if (ref) {
@@ -31,6 +36,10 @@ export function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
 
       return () => undefined;
     });
+
+    if (!returned) {
+      return undefined;
+    }
 
     return () => {
       for (const teardown of teardowns) {


### PR DESCRIPTION
## What

`mergeRefs` returned a combined teardown from every call of the merged ref callback. React 19 stores it as the ref's cleanup and skips the `null` call. React 18 calls the ref with `null` regardless and, in development, reports the returned function at attach and again at the `null` call, so every element carrying a merged ref printed "Unexpected return value from a callback ref" twice per mount and unmount, four times with a `<LottieDisplay>` child. Cosmetic: the `null` call clears every ref and the animation is destroyed from an effect cleanup, so nothing leaks. Reported in #140.

The merged callback now returns a teardown only when one of the refs returned a cleanup of its own, because that ref must then be torn down by it rather than by a `null` call. Otherwise it returns nothing and both versions call it with `null`, which does the same work. No version detection: React 19 takes the `null` call whenever a ref returns nothing. The peer range is unchanged, and the JSDoc no longer claims React 18 ignores the return.

## Verified

- Red-first: a unit test asserting nothing is returned for plain refs failed on both majors; two new tests asserting `<Lottie>` prints nothing to the console across a mount and unmount, alone and with a `<LottieDisplay>` child, failed on React 18 at exactly the measured counts (2 and 4). The React 18 lane had printed the warning 440 times on `main` and stayed green, because the runner does not fail on console output; these tests are what let it go red.
- `pnpm check` green: 492 tests, coverage 100 / 97.46 / 100 / 100, budgets under (`import { Lottie }` 4.8 kB of 4.9), 36 pages rendered. `pnpm check:react18` green: 477 tests on React 18.3.1.
- The packed branch installed whole into fresh React 18.3.1 and 19.2.8 projects and run in real Chromium 151 (Playwright) next to the published 3.1.0; happy-dom gives the same numbers:

| | React 18.3.1, published 3.1.0 | React 18.3.1, this branch | React 19.2.8, published 3.1.0 | React 19.2.8, this branch |
|---|---|---|---|---|
| `<Lottie/>`, warnings at mount / after unmount | 1 / 2 | 0 / 0 | 0 / 0 | 0 / 0 |
| with a `<LottieDisplay>` child | 2 / 4 | 0 / 0 | 0 / 0 | 0 / 0 |
| under StrictMode | 1 / 2 | 0 / 0 | 0 / 0 | 0 / 0 |
| console errors the browser reported | 8, all this warning | 0 | 0 | 0 |
| animations registered, mounted / after unmount | 1 / 0 | 1 / 0 | 1 / 0 | 1 / 0 |
